### PR TITLE
M0 zsu encoder

### DIFF
--- a/software/flow-graphs/README.md
+++ b/software/flow-graphs/README.md
@@ -1,6 +1,6 @@
 # pi-transceiver / software / flow-graphs
 
-basic-ssb-tx.grc is the most basic audio capture -> SSB transmitter I can conceive of in GNU Radio. It can be loaded into GNU Radio Companion 3.8 with gr-limesdr installed. Just set the lime_serial variable (block) value to the serial number of your own LimeSDR, found by running `LimeUtil --find` at the terminal. Click Run, and you'll find a signal at 144.400MHz USB +/- calibration. 
+SSB_TX.grc is the most basic audio capture -> SSB transmitter I can conceive of in GNU Radio. It can be loaded into GNU Radio Companion 3.8 with gr-limesdr installed. Just set the lime_serial variable (block) value to the serial number of your own LimeSDR, found by running `LimeUtil --find` at the terminal. Click Run, and you'll find a signal at 144.400MHz USB +/- calibration. 
 
 Default gain is 60 (who knows what units), frequency is set in the LimeSDR block.
 

--- a/software/rig-controller/rig-controller/Services/FlexKnob.cs
+++ b/software/rig-controller/rig-controller/Services/FlexKnob.cs
@@ -28,6 +28,7 @@ namespace rig_controller.Services
 
                 try
                 {
+                    sp.DtrEnable = true;
                     sp.Open();
                 }
                 catch (Exception)


### PR DESCRIPTION
Turned on DTR control to help with emulated FlexKnob. This may be temporary if we can find a better way to detect the port opening.